### PR TITLE
Use the configBeanDefs

### DIFF
--- a/spring-graalvm-native-substitutions/src/main/java/org/springframework/context/annotation/Target_ConfigurationClassPostProcessor.java
+++ b/spring-graalvm-native-substitutions/src/main/java/org/springframework/context/annotation/Target_ConfigurationClassPostProcessor.java
@@ -64,5 +64,10 @@ public final class Target_ConfigurationClassPostProcessor {
 				configBeanDefs.put(beanName, (AbstractBeanDefinition) beanDef);
 			}
 		}
+		if (configBeanDefs.isEmpty()) {
+			// nothing to enhance -> return immediately
+			return;
+		}
+		throw new BeanDefinitionStoreException("@Configuration classes need to be marked as proxyBeanMethods=false. Found: " + configBeanDefs.keySet());
 	}
 }


### PR DESCRIPTION
```
Date           Sample                   Build Time (s)  Build Mem (GB)  RSS Mem (M)  Image Size (M)  Startup Time (s)  JVM Uptime (s)
20200519-1455  commandlinerunner        61.0            4.43            35.5         26.5            0.03              0.032
20200519-1456  commandlinerunner-agent  55.6            4.05            34.1         21.4            0.039             0.041
20200519-1458  webflux-netty            121.2           5.92            64.5         51.2            0.059             0.061
20200519-1500  webflux-netty-agent      103.1           6.91            65.8         49.7            0.069             0.071
20200519-1503  springmvc-tomcat         127.2           5.76            82.8         64.9            0.082             0.084
20200519-1505  springmvc-tomcat-agent   119.4           6.61            86.6         64.9            0.099             0.101
20200519-1506  jafu                     41.2            2.70            15.5         14.7            0.004             0.005
20200519-1508  jafu-webmvc              80.5            6.09            39.5         42.3            0.016             0.017
20200519-1510  vanilla-thymeleaf        134.7           7.21            76.1         58.0            0.063             0.065
20200519-1512  vanilla-grpc             115.5           6.48            40.0         48.9             
20200519-1516  vanilla-tx               176.7           6.43            116.6        88.7            0.131             0.133

```

So maybe GRPC didn't work? Not sure why that would be the case. Probably unrelated.