### PR TITLE
Fix the webflux-r2dbc sample

### DIFF
--- a/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/r2dbc/Hints.java
+++ b/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/r2dbc/Hints.java
@@ -15,18 +15,32 @@
  */
 package org.springframework.boot.autoconfigure.data.r2dbc;
 
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.r2dbc.dialect.DialectResolver.R2dbcDialectProvider;
+import org.springframework.data.r2dbc.repository.config.R2dbcRepositoryConfigurationExtension;
 import org.springframework.data.r2dbc.repository.support.R2dbcRepositoryFactoryBean;
 import org.springframework.data.r2dbc.repository.support.SimpleR2dbcRepository;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.PropertiesBasedNamedQueries;
+import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
+import org.springframework.data.repository.core.support.RepositoryFragmentsFactoryBean;
 import org.springframework.graalvm.extension.NativeImageConfiguration;
 import org.springframework.graalvm.extension.NativeImageHint;
 import org.springframework.graalvm.extension.TypeInfo;
 import org.springframework.graalvm.type.AccessBits;
 
-@NativeImageHint(trigger=R2dbcRepositoriesAutoConfiguration.class, typeInfos = {
-	@TypeInfo(types= {
-			SimpleR2dbcRepository.class,
-			R2dbcRepositoryFactoryBean.class
-		},access=AccessBits.DECLARED_FIELDS|AccessBits.DECLARED_METHODS|AccessBits.DECLARED_CONSTRUCTORS)
-	})
+@NativeImageHint(trigger = R2dbcRepositoriesAutoConfiguration.class, typeInfos = {
+		@TypeInfo(types = {
+				R2dbcRepositoryFactoryBean.class, RepositoryFactoryBeanSupport.class, R2dbcRepositoryConfigurationExtension.class,
+				MappingContext.class, PropertiesBasedNamedQueries.class, RepositoryFragmentsFactoryBean.class,
+				R2dbcRepositoriesAutoConfigureRegistrar.class,
+				SimpleR2dbcRepository.class,
+				RepositoryMetadata.class,
+				R2dbcDialectProvider.class
+		}, typeNames = {"org.springframework.data.r2dbc.dialect.DialectResolver.R2dbcDialectProvider.BuiltInDialectProvider"}
+				, access = AccessBits.DECLARED_FIELDS | AccessBits.DECLARED_METHODS | AccessBits.DECLARED_CONSTRUCTORS | AccessBits.RESOURCE
+		)
+})
 public class Hints implements NativeImageConfiguration {
+
 }

--- a/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/r2dbc/Hints.java
+++ b/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/r2dbc/Hints.java
@@ -20,6 +20,7 @@ import org.springframework.graalvm.extension.NativeImageHint;
 import org.springframework.graalvm.extension.TypeInfo;
 import org.springframework.graalvm.type.AccessBits;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @NativeImageHint(trigger=R2dbcAutoConfiguration.class, typeInfos= {
@@ -29,7 +30,8 @@ import reactor.core.publisher.Mono;
 				"org.springframework.data.r2dbc.dialect.DialectResolver$BuiltInDialectProvider"
 		},types= {
 				// Can't find it now but there was some form of wrapper list in R2DBC that listed this plus others
-				Mono.class
+				Mono.class,
+				Flux.class
 		},access = AccessBits.DECLARED_CONSTRUCTORS)
 	})
 public class Hints implements NativeImageConfiguration {

--- a/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/r2dbc/Hints.java
+++ b/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/r2dbc/Hints.java
@@ -15,10 +15,23 @@
  */
 package org.springframework.boot.autoconfigure.r2dbc;
 
+import java.sql.Statement;
+
+import org.h2.mvstore.db.MVTableEngine;
+import org.h2.store.fs.FilePathAsync;
+import org.h2.store.fs.FilePathDisk;
+import org.h2.store.fs.FilePathMem;
+import org.h2.store.fs.FilePathNio;
+import org.h2.store.fs.FilePathNioMapped;
+import org.h2.store.fs.FilePathNioMem;
+import org.h2.store.fs.FilePathRetryOnInterrupt;
+import org.h2.store.fs.FilePathSplit;
+import org.h2.store.fs.FilePathZip;
 import org.springframework.graalvm.extension.NativeImageConfiguration;
 import org.springframework.graalvm.extension.NativeImageHint;
 import org.springframework.graalvm.extension.TypeInfo;
 import org.springframework.graalvm.type.AccessBits;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -32,7 +45,20 @@ import reactor.core.publisher.Mono;
 				// Can't find it now but there was some form of wrapper list in R2DBC that listed this plus others
 				Mono.class,
 				Flux.class
-		},access = AccessBits.DECLARED_CONSTRUCTORS)
-	})
+		},access = AccessBits.DECLARED_CONSTRUCTORS),
+
+
+		// not the place for this!!!
+		@TypeInfo(types = {MVTableEngine.class, Statement.class,Statement[].class}),
+		@TypeInfo(types= EmbeddedDatabase.class,typeNames="org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseFactory$EmbeddedDataSourceProxy",
+				access=AccessBits.CLASS|AccessBits.DECLARED_CONSTRUCTORS|AccessBits.DECLARED_METHODS),
+		@TypeInfo(
+				access=AccessBits.CLASS|AccessBits.DECLARED_CONSTRUCTORS,
+				typeNames= {
+						"org.h2.store.fs.FilePathMemLZF","org.h2.store.fs.FilePathNioMemLZF"},
+				types= {
+						FilePathDisk.class, FilePathMem.class, FilePathNioMem.class, FilePathSplit.class, FilePathNio.class, FilePathNioMapped.class, FilePathAsync.class, FilePathZip.class, FilePathRetryOnInterrupt.class}),
+		@TypeInfo(typeNames= "org.springframework.boot.autoconfigure.jdbc.DataSourceInitializerPostProcessor",access=AccessBits.FULL_REFLECTION)
+})
 public class Hints implements NativeImageConfiguration {
 }

--- a/spring-graalvm-native-configuration/src/main/java/org/springframework/data/SpringDataComponentProcessor.java
+++ b/spring-graalvm-native-configuration/src/main/java/org/springframework/data/SpringDataComponentProcessor.java
@@ -262,7 +262,9 @@ public class SpringDataComponentProcessor implements ComponentProcessor {
 
 		return new HashSet<>(Arrays.asList( //
 				"org.springframework.data.mongodb.repository.MongoRepository", //
-				"org.springframework.data.jpa.repository.JpaRepository"));
+				"org.springframework.data.jpa.repository.JpaRepository",
+				"org.springframework.data.r2dbc.repository.R2dbcRepository"
+				));
 	}
 
 	protected String customRepositoryImplementationPostfix() {


### PR DESCRIPTION
Do not merge - needs clarification for trigger h2 setup!

The first of the two commits fixes the issue with the `ReactiveCrudRepository` not being picked up due to failing checks for reactive adapters in the `ReactiveAdapterRegistry`, which is checking for `Flux` where the `Hint` for _r2dbc` only provides `Mono`.

The 2nd commit adds hints for setting up the required embedded h2 instance. All the changes in here should move to a dedicated place and not reside in the `Hints` for r2dbc.