### PR TITLE
Refine SpringDataComponentProcessor.

### DIFF
--- a/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/mongodb/MongoRepositoriesHints.java
+++ b/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/mongodb/MongoRepositoriesHints.java
@@ -29,8 +29,8 @@ import org.springframework.graalvm.type.AccessBits;
 		@TypeInfo(types = {MongoRepositoryFactoryBean.class, RepositoryFactoryBeanSupport.class, MongoRepositoryConfigurationExtension.class,
 				MappingContext.class, PropertiesBasedNamedQueries.class, RepositoryFragmentsFactoryBean.class,
 				QueryByExampleExecutor.class, MongoConfigurationSupport.class, SimpleMongoRepository.class,
-				BeforeConvertCallback.class, BeforeSaveCallback.class, AfterSaveCallback.class, AfterConvertCallback.class,
-				Query.class, Aggregation.class }),
+				BeforeConvertCallback.class, BeforeSaveCallback.class, AfterSaveCallback.class, AfterConvertCallback.class
+		}),
 		@TypeInfo(types = { Properties.class, BeanFactory.class },access = AccessBits.CLASS)
 })
 public class MongoRepositoriesHints implements NativeImageConfiguration {

--- a/spring-graalvm-native-configuration/src/main/resources/proxies.json
+++ b/spring-graalvm-native-configuration/src/main/resources/proxies.json
@@ -13,9 +13,6 @@
   // Spring Data
   ["org.springframework.data.jpa.repository.support.CrudMethodMetadata", "org.springframework.aop.SpringProxy", "org.springframework.aop.framework.Advised", "org.springframework.core.DecoratingProxy"],
   ["org.springframework.data.annotation.QueryAnnotation", "org.springframework.core.annotation.SynthesizedAnnotation"],
-  ["org.springframework.data.mongodb.core.mapping.Document","org.springframework.core.annotation.SynthesizedAnnotation"],
-  ["org.springframework.data.mongodb.core.mapping.Field","org.springframework.core.annotation.SynthesizedAnnotation"],
-  ["org.springframework.data.mongodb.repository.Aggregation","org.springframework.core.annotation.SynthesizedAnnotation"],
 
   // Spring Security
   ["org.springframework.security.config.annotation.authentication.configuration.EnableGlobalAuthentication", "org.springframework.core.annotation.SynthesizedAnnotation"],

--- a/spring-graalvm-native-feature/src/main/java/org/springframework/graalvm/extension/ComponentProcessor.java
+++ b/spring-graalvm-native-feature/src/main/java/org/springframework/graalvm/extension/ComponentProcessor.java
@@ -32,4 +32,5 @@ public interface ComponentProcessor {
 
 	void process(NativeImageContext imageContext, String key, List<String> values);
 
+	default void printSummary() {}
 }

--- a/spring-graalvm-native-feature/src/main/java/org/springframework/graalvm/extension/NativeImageContext.java
+++ b/spring-graalvm-native-feature/src/main/java/org/springframework/graalvm/extension/NativeImageContext.java
@@ -35,9 +35,19 @@ public interface NativeImageContext {
 
 	TypeSystem getTypeSystem();
 
+	default void addReflectiveAccess(Type type, Flag... flags) {
+		addReflectiveAccess(type.getDottedName(), flags);
+	}
+
 	void addReflectiveAccess(String key, Flag... flags);
 
 	void addReflectiveAccessHierarchy(Type type, Flag... flags);
 
 	boolean hasReflectionConfigFor(String key);
+
+	void initializeAtBuildTime(Type type);
+
+	default boolean hasReflectionConfigFor(Type type) {
+		return hasReflectionConfigFor(type.getDottedName());
+	}
 }

--- a/spring-graalvm-native-feature/src/main/java/org/springframework/graalvm/type/Field.java
+++ b/spring-graalvm-native-feature/src/main/java/org/springframework/graalvm/type/Field.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.graalvm.type;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.FieldNode;
+
+/**
+ * @author Christoph Strobl
+ */
+public class Field {
+
+	private FieldNode node;
+	private TypeSystem typeSystem;
+
+	private Lazy<List<Type>> annotations;
+
+	public Field(FieldNode node, TypeSystem typeSystem) {
+
+		this.node = node;
+		this.typeSystem = typeSystem;
+		this.annotations = Lazy.of(this::resolveAnnotations);
+	}
+
+	public List<Type> getAnnotations() {
+		return annotations.get();
+	}
+
+	private List<Type> resolveAnnotations() {
+
+		List<Type> results = null;
+
+		if (node.visibleAnnotations != null) {
+			for (AnnotationNode an : node.visibleAnnotations) {
+				Type annotationType = typeSystem.Lresolve(an.desc, true);
+				if (annotationType != null) {
+					if (results == null) {
+						results = new ArrayList<>();
+					}
+					results.add(annotationType);
+				}
+			}
+		}
+		return results == null ? Collections.emptyList() : results;
+	}
+}

--- a/spring-graalvm-native-feature/src/main/java/org/springframework/graalvm/type/Lazy.java
+++ b/spring-graalvm-native-feature/src/main/java/org/springframework/graalvm/type/Lazy.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.graalvm.type;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * @author Oliver Gierke
+ * @author Mark Paluch
+ * @author Christoph Strobl
+ */
+class Lazy<T> implements Supplier<T> {
+
+	private static final Lazy<?> EMPTY = new Lazy<>(() -> null, null, true);
+
+	private final Supplier<? extends T> supplier;
+	private T value = null;
+	private boolean resolved = false;
+
+	private Lazy(Supplier<? extends T> supplier) {
+		this(supplier, null, false);
+	}
+
+	public Lazy(Supplier<? extends T> supplier, T value, boolean resolved) {
+
+		this.supplier = supplier;
+		this.value = value;
+		this.resolved = resolved;
+	}
+
+	/**
+	 * Creates a new {@link Lazy} to produce an object lazily.
+	 *
+	 * @param <T> the type of which to produce an object of eventually.
+	 * @param supplier the {@link Supplier} to create the object lazily.
+	 * @return
+	 */
+	public static <T> Lazy<T> of(Supplier<? extends T> supplier) {
+		return new Lazy<>(supplier);
+	}
+
+	/**
+	 * Creates a new {@link Lazy} to return the given value.
+	 *
+	 * @param <T> the type of the value to return eventually.
+	 * @param value the value to return.
+	 * @return
+	 */
+	public static <T> Lazy<T> of(T value) {
+		return new Lazy<>(() -> value);
+	}
+
+	/**
+	 * Creates a pre-resolved empty {@link Lazy}.
+	 *
+	 * @return
+	 * @since 2.1
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> Lazy<T> empty() {
+		return (Lazy<T>) EMPTY;
+	}
+
+	/**
+	 * Returns the value created by the configured {@link Supplier}. Will return the calculated instance for subsequent
+	 * lookups.
+	 *
+	 * @return
+	 */
+	public T get() {
+
+		T value = getNullable();
+
+		if (value == null) {
+			throw new IllegalStateException("Expected lazy evaluation to yield a non-null value but got null!");
+		}
+
+		return value;
+	}
+
+	/**
+	 * Returns the {@link Optional} value created by the configured {@link Supplier}, allowing the absence of values in
+	 * contrast to {@link #get()}. Will return the calculated instance for subsequent lookups.
+	 *
+	 * @return
+	 */
+	public Optional<T> getOptional() {
+		return Optional.ofNullable(getNullable());
+	}
+
+	/**
+	 * Returns a new Lazy that will consume the given supplier in case the current one does not yield in a result.
+	 *
+	 * @param supplier must not be {@literal null}.
+	 * @return
+	 */
+	public Lazy<T> or(Supplier<? extends T> supplier) {
+		return Lazy.of(() -> orElseGet(supplier));
+	}
+
+	/**
+	 * Returns a new Lazy that will return the given value in case the current one does not yield in a result.
+	 *
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	public Lazy<T> or(T value) {
+
+
+		return Lazy.of(() -> orElse(value));
+	}
+
+	/**
+	 * Returns the value of the lazy computation or the given default value in case the computation yields
+	 * {@literal null}.
+	 *
+	 * @param value
+	 * @return
+	 */
+	public T orElse(T value) {
+
+		T nullable = getNullable();
+
+		return nullable == null ? value : nullable;
+	}
+
+	/**
+	 * Returns the value of the lazy computation or the value produced by the given {@link Supplier} in case the original
+	 * value is {@literal null}.
+	 *
+	 * @param supplier must not be {@literal null}.
+	 * @return
+	 */
+	private T orElseGet(Supplier<? extends T> supplier) {
+
+		T value = getNullable();
+
+		return value == null ? supplier.get() : value;
+	}
+
+	/**
+	 * Creates a new {@link Lazy} with the given {@link Function} lazily applied to the current one.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @return
+	 */
+	public <S> Lazy<S> map(Function<? super T, ? extends S> function) {
+
+		return Lazy.of(() -> function.apply(get()));
+	}
+
+	/**
+	 * Creates a new {@link Lazy} with the given {@link Function} lazily applied to the current one.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @return
+	 */
+	public <S> Lazy<S> flatMap(Function<? super T, Lazy<? extends S>> function) {
+		return Lazy.of(() -> function.apply(get()).get());
+	}
+
+	/**
+	 * Returns the value of the lazy evaluation.
+	 *
+	 * @return
+	 * @since 2.2
+	 */
+	public T getNullable() {
+
+		T value = this.value;
+
+		if (this.resolved) {
+			return value;
+		}
+
+		value = supplier.get();
+
+		this.value = value;
+		this.resolved = true;
+
+		return value;
+	}
+}

--- a/spring-graalvm-native-feature/src/main/java/org/springframework/graalvm/type/Type.java
+++ b/spring-graalvm-native-feature/src/main/java/org/springframework/graalvm/type/Type.java
@@ -16,20 +16,8 @@
 package org.springframework.graalvm.type;
 
 import java.lang.reflect.Modifier;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
-import java.util.Stack;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -47,6 +35,7 @@ import org.springframework.graalvm.support.SpringFeature;
 
 /**
  * @author Andy Clement
+ * @author Christoph Strobl
  */
 public class Type {
 
@@ -78,10 +67,16 @@ public class Type {
 	private Type[] interfaces;
 
 	private String name;
+	private String dottedName;
 
 	private int dimensions = 0; // >0 for array types
 
+	private final Lazy<List<Field>> fields;
+	private final Lazy<List<Method>> methods;
+	private final Lazy<List<Type>> annotations;
+
 	private Type(TypeSystem typeSystem, ClassNode node, int dimensions) {
+
 		this.typeSystem = typeSystem;
 		this.node = node;
 		this.dimensions = dimensions;
@@ -90,6 +85,15 @@ public class Type {
 			for (int i = 0; i < dimensions; i++) {
 				this.name += "[]";
 			}
+			this.dottedName = name.replace("/", ".");
+			this.fields = Lazy.of(this::resolveFields);
+			this.methods = Lazy.of(this::resolveMethods);
+			this.annotations = Lazy.of(this::resolveAnnotations);
+		} else {
+
+			this.fields = Lazy.empty();
+			this.methods = Lazy.empty();
+			this.annotations = Lazy.empty();
 		}
 	}
 
@@ -105,7 +109,7 @@ public class Type {
 	}
 
 	public String getDottedName() {
-		return name.replace("/", ".");
+		return dottedName;
 	}
 
 	public Type getSuperclass() {
@@ -126,8 +130,8 @@ public class Type {
 	public Type[] getInterfaces() {
 		if (interfaces == null) {
 			if (dimensions != 0) {
-				interfaces = new Type[] { typeSystem.resolveSlashed("java/lang/Cloneable"),
-						typeSystem.resolveSlashed("java/io/Serializable") };
+				interfaces = new Type[]{typeSystem.resolveSlashed("java/lang/Cloneable"),
+						typeSystem.resolveSlashed("java/io/Serializable")};
 			} else {
 				List<String> itfs = node.interfaces;
 				if (itfs.size() == 0) {
@@ -138,14 +142,28 @@ public class Type {
 						Type t = typeSystem.resolveSlashed(itfs.get(i));
 						interfacesOnClasspath.add(t);
 					}
-					interfaces=interfacesOnClasspath.toArray(new Type[interfacesOnClasspath.size()]);
+					interfaces = interfacesOnClasspath.toArray(new Type[interfacesOnClasspath.size()]);
 				}
 			}
 		}
 		return interfaces;
 	}
 
-	/** @return List of slashed interface types */
+	public boolean isPartOfDomain(String packageName) {
+		return belongsToPackage(packageName, true);
+	}
+
+	public boolean belongsToPackage(String packageName, boolean orPartOfSubPackage) {
+		return orPartOfSubPackage ? dottedName.startsWith(packageName) : getPackageName().equals(packageName);
+	}
+
+	public String getPackageName() {
+		return dottedName.substring(0, dottedName.indexOf('.'));
+	}
+
+	/**
+	 * @return List of slashed interface types
+	 */
 	public List<String> getInterfacesStrings() {
 		if (dimensions != 0) {
 			List<String> itfs = new ArrayList<>();
@@ -157,14 +175,16 @@ public class Type {
 		}
 	}
 
-	/** @return slashed supertype name */
+	/**
+	 * @return slashed supertype name
+	 */
 	public String getSuperclassString() {
 		return dimensions > 0 ? "java/lang/Object" : node.superName;
 	}
 
 	/**
 	 * Compute all the types referenced in the signature of this type.
-	 * 
+	 *
 	 * @return
 	 */
 	public List<String> getTypesInSignature() {
@@ -212,7 +232,6 @@ public class Type {
 				return types;
 			}
 		}
-
 	}
 
 	public boolean extendsClass(String clazzname) {
@@ -252,11 +271,11 @@ public class Type {
 		// System.out.println("looking through methods "+node.methods+" for "+string);
 		return dimensions > 0 ? Collections.emptyList()
 				: node.methods.stream().filter(m -> hasAnnotation(m, string)).map(m -> wrap(m))
-						.collect(Collectors.toList());
+				.collect(Collectors.toList());
 	}
-	
+
 	public List<Method> getMethodsWithAnnotationName(String string, boolean checkMetaUsage) {
-		return getMethodsWithAnnotation("L"+string.replace(".", "/")+";",checkMetaUsage);
+		return getMethodsWithAnnotation("L" + string.replace(".", "/") + ";", checkMetaUsage);
 	}
 
 	public List<Method> getMethodsWithAnnotation(String string, boolean checkMetaUsage) {
@@ -276,10 +295,24 @@ public class Type {
 		}
 		return results == null ? Collections.emptyList() : results;
 	}
-	
+
 	public List<Method> getMethods() {
+		return methods.get();
+	}
+
+	private List<Method> resolveMethods() {
 		return dimensions > 0 ? Collections.emptyList()
 				: node.methods.stream().map(m -> wrap(m)).collect(Collectors.toList());
+	}
+
+
+	public List<Field> getFields() {
+		return fields.get();
+	}
+
+	private List<Field> resolveFields() {
+		return dimensions > 0 ? Collections.emptyList()
+				: node.fields.stream().map(it -> new Field(it, typeSystem)).collect(Collectors.toList());
 	}
 
 	public List<Method> getMethodsWithAtBean() {
@@ -339,11 +372,11 @@ public class Type {
 	}
 
 	private List<Type> toAnnotations(List<AnnotationNode> visibleAnnotations) {
-		if (visibleAnnotations==null) {
+		if (visibleAnnotations == null) {
 			return Collections.emptyList();
 		}
 		List<Type> result = new ArrayList<>();
-		for (AnnotationNode an: visibleAnnotations) {
+		for (AnnotationNode an : visibleAnnotations) {
 			result.add(typeSystem.Lresolve(an.desc));
 		}
 		return result;
@@ -666,7 +699,6 @@ public class Type {
 		} catch (MissingTypeException mte) {
 			return false;
 		}
-
 	}
 
 	public boolean isAtConfiguration() {
@@ -709,7 +741,6 @@ public class Type {
 		return false;
 	}
 
-	List<Type> annotations = null;
 
 	public static final List<Type> NO_ANNOTATIONS = Collections.emptyList();
 
@@ -847,21 +878,25 @@ public class Type {
 		return collectedResults;
 	}
 
-	private List<Type> getAnnotations() {
+	public List<Type> getAnnotations() {
+		return annotations.get();
+	}
+
+	private List<Type> resolveAnnotations() {
+
 		if (dimensions > 0) {
 			return Collections.emptyList();
 		}
-		if (annotations == null) {
-			annotations = new ArrayList<>();
-			if (node.visibleAnnotations != null) {
-				for (AnnotationNode an : node.visibleAnnotations) {
-					try {
-						annotations.add(this.typeSystem.Lresolve(an.desc));
-					} catch (MissingTypeException mte) {
-						// that's ok you weren't relying on it anyway!
-					}
+		List<Type> annotations = new ArrayList<>();
+		if (node.visibleAnnotations != null) {
+			for (AnnotationNode an : node.visibleAnnotations) {
+				try {
+					annotations.add(this.typeSystem.Lresolve(an.desc));
+				} catch (MissingTypeException mte) {
+					// that's ok you weren't relying on it anyway!
 				}
 			}
+		}
 //			if (node.invisibleAnnotations != null) {
 //			for (AnnotationNode an: node.invisibleAnnotations) {
 //				try {
@@ -871,9 +906,8 @@ public class Type {
 //				}
 //			}
 //			}
-			if (annotations.size() == 0) {
-				annotations = NO_ANNOTATIONS;
-			}
+		if (annotations.size() == 0) {
+			annotations = NO_ANNOTATIONS;
 		}
 		return annotations;
 	}
@@ -894,7 +928,6 @@ public class Type {
 	/**
 	 * Discover any uses of @Indexed or javax annotations, via direct/meta or
 	 * interface usage. Example output:
-	 * 
 	 * <pre>
 	 * <code>
 	 * org.springframework.samples.petclinic.PetClinicApplication=org.springframework.stereotype.Component
@@ -910,7 +943,7 @@ public class Type {
 		List<Type> relevantAnnotations = new ArrayList<>();
 		collectRelevantStereotypes(this, new HashSet<>(), relevantAnnotations);
 		List<Type> types = getJavaxAnnotations();
-		for (Type t: types) {
+		for (Type t : types) {
 			if (!relevantAnnotations.contains(t)) {
 				relevantAnnotations.add(t);
 			}
@@ -921,31 +954,31 @@ public class Type {
 			return null;
 		}
 	}
-	
+
 	private void collectRelevantStereotypes(Type type, Set<Type> seen, List<Type> collector) {
-		if (type == null || type.dimensions>0 || !seen.add(type)) {
+		if (type == null || type.dimensions > 0 || !seen.add(type)) {
 			return;
 		}
 		List<Type> ts = type.getAnnotatedElementsInHierarchy(
 				a -> a.desc.equals("Lorg/springframework/stereotype/Indexed;"));
-		for (Type t: ts) {
+		for (Type t : ts) {
 			if (!collector.contains(t)) {
 				collector.add(t);
 			}
 		}
-		for (Type inttype: type.getInterfaces()) {
+		for (Type inttype : type.getInterfaces()) {
 			collectRelevantStereotypes(inttype, seen, collector);
 		}
-		collectRelevantStereotypes(type.getSuperclass(),seen,collector);
+		collectRelevantStereotypes(type.getSuperclass(), seen, collector);
 	}
-	
+
 	public Entry<Type, List<Type>> getMetaComponentTaggedAnnotations() {
 		if (dimensions > 0)
 			return null;
 		List<Type> relevantAnnotations = new ArrayList<>();
 		List<Type> indexedTypesInHierachy = getAnnotatedElementsInHierarchy(
-				a -> a.desc.equals("Lorg/springframework/stereotype/Component;"),true);
-		for (Type t: indexedTypesInHierachy) {
+				a -> a.desc.equals("Lorg/springframework/stereotype/Component;"), true);
+		for (Type t : indexedTypesInHierachy) {
 			if (t.isAnnotation()) {
 				relevantAnnotations.add(t);
 			}
@@ -999,7 +1032,7 @@ public class Type {
 	private List<Type> getAnnotatedElementsInHierarchy(Predicate<AnnotationNode> p) {
 		return getAnnotatedElementsInHierarchy(p, new HashSet<>(), false);
 	}
-	
+
 	private List<Type> getAnnotatedElementsInHierarchy(Predicate<AnnotationNode> p, boolean includeInterim) {
 		return getAnnotatedElementsInHierarchy(p, new HashSet<>(), includeInterim);
 	}
@@ -1018,7 +1051,7 @@ public class Type {
 						Type annoType = typeSystem.Lresolve(an.desc, true);
 						if (annoType != null) {
 							List<Type> ts = annoType.getAnnotatedElementsInHierarchy(p, seen, includeInterim);
-							if (ts.size()!=0 && includeInterim) {
+							if (ts.size() != 0 && includeInterim) {
 								// Include interim enables us to catch intermediate annotations on the route to
 								// the one that passes the predicate test.
 								results.add(this);
@@ -1117,17 +1150,17 @@ public class Type {
 			}
 		}
 		try {
-		if (isImportSelector() && hints.size() == 0) {
-			// Failing early as this will likely result in a problem later - fix is
-			// typically (right now) to add a new Hint in the configuration module
-			if (ConfigOptions.areMissingSelectorHintsAnError()) {
-				throw new IllegalStateException("No access hint found for import selector: " + getDottedName());
-			} else {
-				System.out.println("WARNING: No access hint found for import selector: " + getDottedName());
+			if (isImportSelector() && hints.size() == 0) {
+				// Failing early as this will likely result in a problem later - fix is
+				// typically (right now) to add a new Hint in the configuration module
+				if (ConfigOptions.areMissingSelectorHintsAnError()) {
+					throw new IllegalStateException("No access hint found for import selector: " + getDottedName());
+				} else {
+					System.out.println("WARNING: No access hint found for import selector: " + getDottedName());
+				}
 			}
-		}
 		} catch (MissingTypeException mte) {
-			System.out.println("Unable to determine if type "+getName()+" is import selector - can't fully resolve hierarchy - ignoring");
+			System.out.println("Unable to determine if type " + getName() + " is import selector - can't fully resolve hierarchy - ignoring");
 		}
 		return hints.size() == 0 ? Collections.emptyList() : hints;
 	}
@@ -1173,12 +1206,12 @@ public class Type {
 
 	private void addInners(List<String> propertiesTypes) {
 		List<String> extras = new ArrayList<>();
-		for (String propertiesType: propertiesTypes) {
-			Type type = typeSystem.Lresolve(propertiesType,true);
-			if (type !=null) {
+		for (String propertiesType : propertiesTypes) {
+			Type type = typeSystem.Lresolve(propertiesType, true);
+			if (type != null) {
 				// TODO recurse all the way down
 				List<Type> nestedTypes = type.getNestedTypes();
-				for (Type nestedType: nestedTypes) {
+				for (Type nestedType : nestedTypes) {
 					extras.add(nestedType.getDescriptor());
 				}
 			}
@@ -1225,7 +1258,7 @@ public class Type {
 			}
 			System.out.println(this.getName()
 					+ " has inners " + nestMembers.stream().map(f -> "oo=" + this.getDescriptor() + "::o=" + f.outerName
-							+ "::n=" + f.name + "::in=" + f.innerName).collect(Collectors.joining(","))
+					+ "::n=" + f.name + "::in=" + f.innerName).collect(Collectors.joining(","))
 					+ "  >> " + result);
 		}
 		return result.toArray(new Type[0]);
@@ -1350,14 +1383,14 @@ public class Type {
 		List<Type> result = new ArrayList<>();
 		for (AnnotationNode an : node.visibleAnnotations) {
 			if (an.desc.equals("Lorg/springframework/boot/autoconfigure/AutoConfigureAfter;") ||
-				an.desc.equals("Lorg/springframework/boot/autoconfigure/AutoConfigureBefore;")) {
+					an.desc.equals("Lorg/springframework/boot/autoconfigure/AutoConfigureBefore;")) {
 				List<Object> values = an.values;
 				if (values != null) {
 					for (int i = 0; i < values.size(); i += 2) {
 						if (values.get(i).equals("value")) {
 							List<org.objectweb.asm.Type> types = (List<org.objectweb.asm.Type>) values.get(i + 1);
 							for (org.objectweb.asm.Type type : types) {
-								Type t = typeSystem.Lresolve(type.getDescriptor(),true);
+								Type t = typeSystem.Lresolve(type.getDescriptor(), true);
 								if (t != null) {
 									result.add(t);
 								}
@@ -1393,7 +1426,7 @@ public class Type {
 	 * and from them build CompilationHints, taking care to convert class references
 	 * to strings because they may not be resolvable. TODO ok to discard those that
 	 * aren't resolvable at this point?
-	 * 
+	 *
 	 * @return
 	 */
 	public List<CompilationHint> unpackConfigurationHints() {
@@ -1463,7 +1496,7 @@ public class Type {
 		}
 		if (ch.getTargetType() == null) {
 			ch.setTargetType("java.lang.Object");// TODO should be set from annotation default value, not duplicated
-													// here
+			// here
 		}
 		return ch;
 	}
@@ -1493,7 +1526,6 @@ public class Type {
 			if (resolvedType != null) {
 				ch.addDependantType(typeName, accessRequired == -1 ? inferTypeKind(resolvedType) : accessRequired);
 			}
-
 		}
 	}
 
@@ -1634,7 +1666,7 @@ public class Type {
 		reader.accept(tpm);
 		return tpm.getTypeParameter(typeParameterNumber);
 	}
-	
+
 	static class TypeParamFinder extends SignatureVisitor {
 
 		String typeparameter;
@@ -1686,25 +1718,24 @@ public class Type {
 			super.visitClassType(name);
 			nextIsBoundType = false;
 		}
-
 	}
 
 	public String fetchReactiveCrudRepositoryType() {
-		return findTypeParameterInSupertype("org.springframework.data.repository.reactive.ReactiveCrudRepository",0);
+		return findTypeParameterInSupertype("org.springframework.data.repository.reactive.ReactiveCrudRepository", 0);
 	}
 
 	public String fetchCrudRepositoryType() {
-		return findTypeParameterInSupertype("org.springframework.data.repository.CrudRepository",0);
+		return findTypeParameterInSupertype("org.springframework.data.repository.CrudRepository", 0);
 	}
 
 	public String fetchJpaRepositoryType() {
-		return findTypeParameterInSupertype("org.springframework.data.jpa.repository.JpaRepository",0);
+		return findTypeParameterInSupertype("org.springframework.data.jpa.repository.JpaRepository", 0);
 	}
-	
+
 	/**
 	 * Verify this type as a component, checking everything is set correctly for
 	 * native-image construction to succeed.
-	 * 
+	 *
 	 * @throws VerificationException if anything looks wrong with the component
 	 */
 	public void verifyComponent() {
@@ -1712,59 +1743,60 @@ public class Type {
 	}
 
 	/**
-	 *  
+	 *
 	 */
 	private void verifyProxyBeanMethodsSetting() {
 		List<Method> methodsWithAtBean = getMethodsWithAtBean();
-		System.out.println("methodsWithAtBean #"+methodsWithAtBean.size());
+		System.out.println("methodsWithAtBean #" + methodsWithAtBean.size());
 		if (methodsWithAtBean.size() != 0) {
 			List<AnnotationNode> annos = collectAnnotations();
 			annos = filterAnnotations(annos,
-				an -> {
-					Type annotationType = typeSystem.Lresolve(an.desc);
-					return annotationType.hasMethod("proxyBeanMethods");
-				});
+					an -> {
+						Type annotationType = typeSystem.Lresolve(an.desc);
+						return annotationType.hasMethod("proxyBeanMethods");
+					});
 			// Rule:
 			// At least one annotation in the list has to be setting proxyBeanMethods=false.
 			// Some may not supply it if they are being aliased by other values.
 			// TODO this does not check the default value for proxyBeanMethods
 			// TODO this does not verify/follow AliasFor usage
 			boolean atLeastSetFalseSomewhere = false;
-			for (AnnotationNode anode: annos) {
+			for (AnnotationNode anode : annos) {
 				if (hasValue(anode, "proxyBeanMethods")) {
-					Boolean value = (Boolean)getValue(anode, "proxyBeanMethods");
+					Boolean value = (Boolean) getValue(anode, "proxyBeanMethods");
 					if (!value) {
 						atLeastSetFalseSomewhere = true;
 					}
 				}
 			}
 			if (!atLeastSetFalseSomewhere) {
-				throw new VerificationException("Component "+this.getDottedName()+" does not specify annotation value proxyBeanMethods=false to avoid CGLIB proxies");
+				throw new VerificationException("Component " + this.getDottedName() + " does not specify annotation value proxyBeanMethods=false to avoid CGLIB proxies");
 			}
 		}
 	}
-	
+
 	/**
 	 * For an {@link AnnotationNode} retrieve the value for a particular attribute, will throw
 	 * an exception if no value is set for that attribute.
-	 * @param node the annotation node whose values should be checked
+	 *
+	 * @param anode the annotation node whose values should be checked
 	 * @param name the annotation attribute name being searched for
 	 * @return the value of that attribute if set on that annotation node
 	 * @throws IllegalStateException if that attribute name is not set
 	 */
 	private Object getValue(AnnotationNode anode, String name) {
 		List<Object> values = anode.values;
-		for (int i=0;i< values.size(); i+=2) {
+		for (int i = 0; i < values.size(); i += 2) {
 			if (values.get(i).toString().equals(name)) {
-				return values.get(i+1);
+				return values.get(i + 1);
 			}
 		}
-		return new IllegalStateException("Attribute "+name+" not set on the specified annotation, precede this call to getValue() with a hasValue() check");
+		return new IllegalStateException("Attribute " + name + " not set on the specified annotation, precede this call to getValue() with a hasValue() check");
 	}
 
 	/**
 	 * For an {@link AnnotationNode} check if it specifies a value for a particular attribute.
-	 * 
+	 *
 	 * @param node the annotation node whose values should be checked
 	 * @param name the annotation attribute name being searched for
 	 * @return true if the annotation did specify a value for that attribute
@@ -1783,14 +1815,14 @@ public class Type {
 
 	public boolean hasMethod(String methodName) {
 		List<MethodNode> methods = node.methods;
-		for (MethodNode method: methods) {
+		for (MethodNode method : methods) {
 			if (method.name.equals(methodName)) {
 				return true;
 			}
 		}
 		return false;
 	}
-	
+
 	private List<AnnotationNode> filterAnnotations(List<AnnotationNode> input, Predicate<AnnotationNode> filter) {
 		return input.stream().filter(filter).collect(Collectors.toList());
 	}
@@ -1803,7 +1835,7 @@ public class Type {
 
 	private void collectAnnotationsHelper(List<AnnotationNode> collector, Set<String> seen) {
 		if (node.visibleAnnotations != null) {
-			for (AnnotationNode anno: node.visibleAnnotations) {
+			for (AnnotationNode anno : node.visibleAnnotations) {
 				if (!seen.add(anno.desc)) {
 					continue;
 				}
@@ -1817,18 +1849,17 @@ public class Type {
 	public List<Method> getMethods(Predicate<Method> predicate) {
 		return dimensions > 0 ? Collections.emptyList()
 				: node.methods.stream().map(m -> wrap(m)).filter(m -> predicate.test(m))
-						.collect(Collectors.toList());
+				.collect(Collectors.toList());
 	}
 
 	public boolean equals(Object that) {
-		return (that instanceof Type) && 
-				(((Type)that).name.equals(this.name)) && 
-				(((Type)that).dimensions==this.dimensions) &&
-				(((Type)that).node.equals(this.node));
-	}
-	
-	public int hashCode() {
-		return node.hashCode()*37;
+		return (that instanceof Type) &&
+				(((Type) that).name.equals(this.name)) &&
+				(((Type) that).dimensions == this.dimensions) &&
+				(((Type) that).node.equals(this.node));
 	}
 
+	public int hashCode() {
+		return node.hashCode() * 37;
+	}
 }


### PR DESCRIPTION
The `SpringDataComponentProcessor` now detects required annotations and registers them for reflective access so they do no longer need to be part of the `Hints`.
Some of the logic held in `ResourceHandler` moved to the `ComponentProcessor`.
Logging has also been improved to be less verbose by default.

Closes: #158