### PR TITLE
Split Hints for common Spring Data infrastructure and store specifics.

### DIFF
--- a/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/SpringDataCommonsHints.java
+++ b/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/SpringDataCommonsHints.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure.data;
+
+import java.util.Properties;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.repository.core.support.PropertiesBasedNamedQueries;
+import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
+import org.springframework.data.repository.core.support.RepositoryFragmentsFactoryBean;
+import org.springframework.data.repository.core.support.TransactionalRepositoryFactoryBeanSupport;
+import org.springframework.data.repository.query.QueryByExampleExecutor;
+import org.springframework.graalvm.extension.NativeImageConfiguration;
+import org.springframework.graalvm.extension.NativeImageHint;
+import org.springframework.graalvm.extension.TypeInfo;
+import org.springframework.graalvm.type.AccessBits;
+
+@NativeImageHint(trigger = AbstractRepositoryConfigurationSourceSupport.class, typeInfos = {
+		@TypeInfo(types = {
+				RepositoryFactoryBeanSupport.class,
+				RepositoryFragmentsFactoryBean.class,
+				TransactionalRepositoryFactoryBeanSupport.class,
+				QueryByExampleExecutor.class,
+				MappingContext.class,
+				PropertiesBasedNamedQueries.class,
+		}),
+		@TypeInfo(types = {Properties.class, BeanFactory.class}, access = AccessBits.CLASS)
+})
+public class SpringDataCommonsHints implements NativeImageConfiguration {
+
+}

--- a/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/jpa/JpaRepositoriesHints.java
+++ b/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/jpa/JpaRepositoriesHints.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,38 +17,24 @@ package org.springframework.boot.autoconfigure.data.jpa;
 
 import org.springframework.data.jpa.repository.support.JpaEvaluationContextExtension;
 import org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean;
-import org.springframework.data.repository.core.support.PropertiesBasedNamedQueries;
-import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
-import org.springframework.data.repository.core.support.RepositoryFragmentsFactoryBean;
-import org.springframework.data.repository.core.support.TransactionalRepositoryFactoryBeanSupport;
-import org.springframework.graalvm.extension.NativeImageHint;
 import org.springframework.graalvm.extension.NativeImageConfiguration;
+import org.springframework.graalvm.extension.NativeImageHint;
 import org.springframework.graalvm.extension.TypeInfo;
 import org.springframework.graalvm.type.AccessBits;
 import org.springframework.orm.jpa.SharedEntityManagerCreator;
 
-@NativeImageHint(trigger=JpaRepositoriesAutoConfiguration.class,typeInfos= {
-		@TypeInfo(types= {
+@NativeImageHint(trigger = JpaRepositoriesAutoConfiguration.class, typeInfos = {
+		@TypeInfo(types = {
 				SharedEntityManagerCreator.class, // TODO is this one in the right place?
 				JpaRepositoryFactoryBean.class,
-				RepositoryFactoryBeanSupport.class,
-				TransactionalRepositoryFactoryBeanSupport.class,
 				JpaEvaluationContextExtension.class,
-				PropertiesBasedNamedQueries.class, // TODO what is the right trigger for this one? Basically, are there other auto configs that trigger which would need it?
-				RepositoryFragmentsFactoryBean.class, // TODO ditto
-				org.springframework.data.jpa.repository.Query.class,
-				org.springframework.data.jpa.repository.query.Procedure.class,
-				org.springframework.data.jpa.repository.EntityGraph.class,
-				org.springframework.data.jpa.repository.Lock.class,
-				org.springframework.data.jpa.repository.Modifying.class,
-				org.springframework.data.jpa.repository.QueryHints.class,
-				org.springframework.data.jpa.repository.Temporal.class
-		},typeNames= {
+		}, typeNames = {
 				"org.springframework.data.jpa.repository.config.JpaMetamodelMappingContextFactoryBean",
 				"org.springframework.data.jpa.util.JpaMetamodelCacheCleanup"
-				},access=AccessBits.CLASS|AccessBits.DECLARED_METHODS|AccessBits.DECLARED_CONSTRUCTORS|AccessBits.RESOURCE)
-	})
+		}, access = AccessBits.CLASS | AccessBits.DECLARED_METHODS | AccessBits.DECLARED_CONSTRUCTORS | AccessBits.RESOURCE)
+})
 // TODO Why can't I make this conditional on JpaReposAutoConfig above? The vanilla-orm sample needs this but JpaRepositoriesAutoConfiguration is not active in that sample
 //@ConfigurationHint(typeInfos= {@TypeInfo(types= {PersistenceAnnotationBeanPostProcessor.class})}) // temporarily moved this to be HibernateJpaConfiguration dependant
 public class JpaRepositoriesHints implements NativeImageConfiguration {
+
 }

--- a/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/mongodb/MongoRepositoriesHints.java
+++ b/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/mongodb/MongoRepositoriesHints.java
@@ -1,37 +1,31 @@
 package org.springframework.boot.autoconfigure.data.mongodb;
 
-import java.util.Properties;
-
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfiguration;
-import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.config.MongoConfigurationSupport;
 import org.springframework.data.mongodb.core.mapping.event.AfterConvertCallback;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveCallback;
 import org.springframework.data.mongodb.core.mapping.event.BeforeConvertCallback;
 import org.springframework.data.mongodb.core.mapping.event.BeforeSaveCallback;
-import org.springframework.data.mongodb.repository.Aggregation;
-import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.config.MongoRepositoryConfigurationExtension;
 import org.springframework.data.mongodb.repository.support.MongoRepositoryFactoryBean;
 import org.springframework.data.mongodb.repository.support.SimpleMongoRepository;
-import org.springframework.data.repository.core.support.PropertiesBasedNamedQueries;
-import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
-import org.springframework.data.repository.core.support.RepositoryFragmentsFactoryBean;
-import org.springframework.data.repository.query.QueryByExampleExecutor;
 import org.springframework.graalvm.extension.NativeImageConfiguration;
 import org.springframework.graalvm.extension.NativeImageHint;
 import org.springframework.graalvm.extension.TypeInfo;
-import org.springframework.graalvm.type.AccessBits;
 
 
-@NativeImageHint(trigger= MongoRepositoriesAutoConfiguration.class, typeInfos= {
-		@TypeInfo(types = {MongoRepositoryFactoryBean.class, RepositoryFactoryBeanSupport.class, MongoRepositoryConfigurationExtension.class,
-				MappingContext.class, PropertiesBasedNamedQueries.class, RepositoryFragmentsFactoryBean.class,
-				QueryByExampleExecutor.class, MongoConfigurationSupport.class, SimpleMongoRepository.class,
-				BeforeConvertCallback.class, BeforeSaveCallback.class, AfterSaveCallback.class, AfterConvertCallback.class
-		}),
-		@TypeInfo(types = { Properties.class, BeanFactory.class },access = AccessBits.CLASS)
+@NativeImageHint(trigger = MongoRepositoriesAutoConfiguration.class, typeInfos = {
+		@TypeInfo(types = {
+				MongoRepositoryFactoryBean.class,
+				MongoRepositoryConfigurationExtension.class,
+				MongoConfigurationSupport.class,
+				SimpleMongoRepository.class,
+				BeforeConvertCallback.class,
+				BeforeSaveCallback.class,
+				AfterSaveCallback.class,
+				AfterConvertCallback.class
+		})
 })
 public class MongoRepositoriesHints implements NativeImageConfiguration {
+
 }

--- a/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/r2dbc/R2dbcRepositoriesHints.java
+++ b/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/r2dbc/R2dbcRepositoriesHints.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,15 +15,11 @@
  */
 package org.springframework.boot.autoconfigure.data.r2dbc;
 
-import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.r2dbc.dialect.DialectResolver.R2dbcDialectProvider;
 import org.springframework.data.r2dbc.repository.config.R2dbcRepositoryConfigurationExtension;
 import org.springframework.data.r2dbc.repository.support.R2dbcRepositoryFactoryBean;
 import org.springframework.data.r2dbc.repository.support.SimpleR2dbcRepository;
 import org.springframework.data.repository.core.RepositoryMetadata;
-import org.springframework.data.repository.core.support.PropertiesBasedNamedQueries;
-import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
-import org.springframework.data.repository.core.support.RepositoryFragmentsFactoryBean;
 import org.springframework.graalvm.extension.NativeImageConfiguration;
 import org.springframework.graalvm.extension.NativeImageHint;
 import org.springframework.graalvm.extension.TypeInfo;
@@ -31,8 +27,8 @@ import org.springframework.graalvm.type.AccessBits;
 
 @NativeImageHint(trigger = R2dbcRepositoriesAutoConfiguration.class, typeInfos = {
 		@TypeInfo(types = {
-				R2dbcRepositoryFactoryBean.class, RepositoryFactoryBeanSupport.class, R2dbcRepositoryConfigurationExtension.class,
-				MappingContext.class, PropertiesBasedNamedQueries.class, RepositoryFragmentsFactoryBean.class,
+				R2dbcRepositoryFactoryBean.class,
+				R2dbcRepositoryConfigurationExtension.class,
 				R2dbcRepositoriesAutoConfigureRegistrar.class,
 				SimpleR2dbcRepository.class,
 				RepositoryMetadata.class,

--- a/spring-graalvm-native-configuration/src/main/resources/META-INF/services/org.springframework.graalvm.extension.NativeImageConfiguration
+++ b/spring-graalvm-native-configuration/src/main/resources/META-INF/services/org.springframework.graalvm.extension.NativeImageConfiguration
@@ -10,6 +10,7 @@ org.springframework.boot.autoconfigure.aop.AopHints
 org.springframework.boot.autoconfigure.cache.CacheHints
 org.springframework.boot.autoconfigure.condition.ConditionalHints
 org.springframework.boot.autoconfigure.data.RepositoriesHints
+org.springframework.boot.autoconfigure.data.SpringDataCommonsHints
 org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesHints
 org.springframework.boot.autoconfigure.data.mongodb.MongoRepositoriesHints
 org.springframework.boot.autoconfigure.data.r2dbc.R2dbcRepositoriesHints


### PR DESCRIPTION
Use `AbstractRepositoryConfigurationSourceSupport` as trigger for common Spring Data infrastructure like `RepositoryFactoryBeanSupport`. This allows hints for dedicated modules to be reduced to store specifics.

Closes: #159 