### PR TITLE
Add substitution for AnnotationConfigUtils

### DIFF
--- a/spring-graalvm-native-substitutions/src/main/java/org/springframework/context/annotation/Target_AnnotationConfigUtils.java
+++ b/spring-graalvm-native-substitutions/src/main/java/org/springframework/context/annotation/Target_AnnotationConfigUtils.java
@@ -1,0 +1,32 @@
+package org.springframework.context.annotation;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import org.springframework.beans.factory.config.BeanDefinitionHolder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.graalvm.substitutions.OnlyIfPresent;
+import org.springframework.lang.Nullable;
+
+@TargetClass(className = "org.springframework.context.annotation.AnnotationConfigUtils", onlyWith = { FunctionalMode.class, OnlyIfPresent.class })
+final class Target_AnnotationConfigUtils {
+
+    @Substitute
+    public static Set<BeanDefinitionHolder> registerAnnotationConfigProcessors(BeanDefinitionRegistry registry,
+            @Nullable Object source) {
+        return Collections.emptySet();
+    }
+}
+
+class FunctionalMode implements Predicate<String> {
+
+    @Override
+    public boolean test(String type) {
+        return System.getProperty("spring.native.mode", "default").equals("functional");
+    }
+
+}


### PR DESCRIPTION
Since we don't support Annotations at all when
spring.native.mode=functional it's better to just mask it out for
now. Better still would be if Spring Boot would allow us to
modify the BeanDefinitionLoader/