### PR TITLE
Add reflection tweaks to support Spring Boot's WebApplicationType

### DIFF
--- a/spring-graalvm-native-feature/src/main/java/org/springframework/graalvm/support/ReflectionHandler.java
+++ b/spring-graalvm-native-feature/src/main/java/org/springframework/graalvm/support/ReflectionHandler.java
@@ -158,9 +158,20 @@ public class ReflectionHandler {
 		if (rra.resolveType("org.springframework.web.servlet.DispatcherServlet") != null) {
 			addAccess("org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedWebappClassLoader", Flag.allDeclaredConstructors, Flag.allDeclaredMethods);
 		}
+		registerWebApplicationTypeClasses();
 
 		registerLogAdapterClassesIfNeeded();
 		registerLogbackIfNeeded();
+	}
+
+	private void registerWebApplicationTypeClasses() {
+		if (rra.resolveType("org.springframework.web.reactive.DispatcherHandler") !=null && rra.resolveType("org.springframework.web.servlet.DispatcherServlet") == null && rra.resolveType("org.glassfish.jersey.servlet.ServletContainer") == null) {
+			addAccess("org.springframework.web.reactive.DispatcherHandler");
+		} else
+		if (rra.resolveType("javax.servlet.Servlet") !=null && rra.resolveType("org.springframework.web.context.ConfigurableWebApplicationContext") != null) {
+			addAccess("javax.servlet.Servlet");
+			addAccess("org.springframework.web.context.ConfigurableWebApplicationContext");
+		}
 	}
 
 	public void register(DuringSetupAccess a) {
@@ -288,6 +299,8 @@ public class ReflectionHandler {
 		}
 		registerLogAdapterClassesIfNeeded();
 		registerLogbackIfNeeded();
+
+		registerWebApplicationTypeClasses();
 
 		if (!ConfigOptions.shouldRemoveYamlSupport()) {
 			addAccess("org.yaml.snakeyaml.Yaml", Flag.allDeclaredConstructors, Flag.allDeclaredMethods);


### PR DESCRIPTION
Allows user to remove these entries from reflect-config.json. With WebFlux:

```
  {
    "name": "org.springframework.web.reactive.DispatcherHandler"
  }
```

and with MVC:

```
  {
    "name": "javax.servlet.Servlet"
  },
  {
    "name": "org.springframework.web.context.ConfigurableWebApplicationContext"
  }
```