### PR TITLE
Fix Spring Data Elasticsearch sample.

### DIFF
--- a/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchRepositoriesHints.java
+++ b/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/elasticsearch/ElasticsearchRepositoriesHints.java
@@ -29,6 +29,8 @@ import org.springframework.data.elasticsearch.repository.support.ElasticsearchRe
 import org.springframework.data.elasticsearch.repository.support.ReactiveElasticsearchRepositoryFactoryBean;
 import org.springframework.data.elasticsearch.repository.support.SimpleElasticsearchRepository;
 import org.springframework.data.elasticsearch.repository.support.SimpleReactiveElasticsearchRepository;
+import org.springframework.graalvm.extension.InitializationInfo;
+import org.springframework.graalvm.extension.InitializationTime;
 import org.springframework.graalvm.extension.NativeImageConfiguration;
 import org.springframework.graalvm.extension.NativeImageHint;
 import org.springframework.graalvm.extension.ProxyInfo;
@@ -48,7 +50,10 @@ import org.springframework.graalvm.type.AccessBits;
 						BeforeConvertCallback.class,
 						AfterSaveCallback.class,
 						AfterConvertCallback.class,
-				})
+				}),
+				@TypeInfo(types = {
+						org.elasticsearch.Version.class
+				}, access = AccessBits.ALL)
 		},
 		resourcesInfos = @ResourcesInfo(patterns = "versions.properties"))
 @NativeImageHint(trigger = ReactiveElasticsearchRepositoriesAutoConfiguration.class,
@@ -66,6 +71,14 @@ import org.springframework.graalvm.type.AccessBits;
 								XContentParser.class
 						},
 						typeNames = { // todo check access only on fromXContent method
+
+								"org.elasticsearch.client.core.MainResponse",
+								"org.elasticsearch.client.core.AcknowledgedResponse",
+								"org.elasticsearch.client.core.CountResponse",
+								"org.elasticsearch.client.core.MultiTermVectorsResponse",
+								"org.elasticsearch.index.reindex.BulkByScrollResponse",
+								"org.elasticsearch.action.admin.indices.refresh.RefreshResponse",
+
 								"org.elasticsearch.action.search.SearchResponse",
 								"org.elasticsearch.action.get.GetResponse",
 								"org.elasticsearch.action.get.MultiGetResponse",
@@ -74,7 +87,10 @@ import org.springframework.graalvm.type.AccessBits;
 								"org.elasticsearch.action.main.MainResponse",
 								"org.elasticsearch.action.search.MultiSearchResponse",
 								"org.elasticsearch.action.search.ClearScrollResponse",
-						})
+						}),
+				@TypeInfo(types = {
+						org.elasticsearch.Version.class
+				}, access = AccessBits.ALL),
 		},
 		proxyInfos = {
 				@ProxyInfo(types = {XContentParser.class})
@@ -88,8 +104,58 @@ import org.springframework.graalvm.type.AccessBits;
 						org.apache.logging.log4j.message.DefaultFlowMessageFactory.class,
 						org.apache.logging.log4j.message.ParameterizedMessageFactory.class,
 						org.apache.logging.log4j.message.ReusableMessageFactory.class
-				}, access = AccessBits.DECLARED_CONSTRUCTORS)
-		})
+				}, access = AccessBits.DECLARED_CONSTRUCTORS),
+				@TypeInfo(typeNames = {
+						// those cause a lot of erros and warnings in logs if not present
+						"io.netty.buffer.AbstractByteBufAllocator",
+						"io.netty.buffer.PooledByteBufAllocator",
+						"io.netty.channel.ChannelDuplexHandler",
+						"io.netty.channel.ChannelHandlerAdapter",
+						"io.netty.channel.ChannelInboundHandlerAdapter",
+						"io.netty.channel.ChannelInitializer",
+						"io.netty.channel.ChannelOutboundHandlerAdapter",
+						"io.netty.channel.CombinedChannelDuplexHandler",
+						"io.netty.channel.DefaultChannelPipeline$HeadContext",
+						"io.netty.channel.DefaultChannelPipeline$TailContext",
+						"io.netty.channel.embedded.EmbeddedChannel",
+						"io.netty.channel.socket.nio.NioSocketChannel",
+						"io.netty.handler.codec.ByteToMessageDecoder",
+						"io.netty.handler.codec.compression.JdkZlibDecoder",
+						"io.netty.handler.codec.dns.DatagramDnsQueryEncoder",
+						"io.netty.handler.codec.dns.DnsResponseDecoder",
+						"io.netty.handler.codec.dns.TcpDnsResponseDecoder",
+						"io.netty.handler.codec.http.HttpClientCodec",
+						"io.netty.handler.codec.http.HttpContentDecoder",
+						"io.netty.handler.codec.http.HttpContentDecompressor",
+						"io.netty.handler.codec.LengthFieldBasedFrameDecoder",
+						"io.netty.handler.codec.MessageToByteEncoder",
+						"io.netty.handler.codec.MessageToMessageDecoder",
+						"io.netty.handler.timeout.IdleStateHandler",
+						"io.netty.handler.timeout.ReadTimeoutHandler",
+						"io.netty.handler.timeout.WriteTimeoutHandler",
+						"io.netty.resolver.dns.DnsNameResolver",
+						"io.netty.resolver.dns.DnsNameResolver$1",
+						"io.netty.resolver.dns.DnsNameResolver$AddressedEnvelopeAdapter",
+						"io.netty.resolver.dns.DnsNameResolver$DnsResponseHandler",
+						"io.netty.resolver.InetNameResolver",
+						"io.netty.resolver.SimpleNameResolver",
+						"io.netty.util.AbstractChannel",
+						"io.netty.util.DefaultAttributeMap",
+						"io.netty.util.ReferenceCountUtil",
+						"reactor.netty.resources.DefaultPooledConnectionProvider",
+						"reactor.netty.resources.DefaultPooledConnectionProvider$PooledConnectionAllocator$",
+						"reactor.netty.resources.DefaultPooledConnectionProvider$PooledConnectionAllocator$PooledConnectionInitializer",
+						"reactor.netty.resources.PooledConnectionProvider",
+						"reactor.netty.transport.TransportConfig$TransportChannelInitializer"
+				})
+		}, initializationInfos = {
+			@InitializationInfo(typeNames = {
+					"org.apache.lucene.util.Constants",
+					"org.elasticsearch.common.unit.TimeValue",
+					"org.apache.lucene.util.RamUsageEstimator"
+			}, initTime = InitializationTime.BUILD)
+		}
+)
 public class ElasticsearchRepositoriesHints implements NativeImageConfiguration {
 
 }

--- a/spring-graalvm-native-docs/src/main/asciidoc/support.adoc
+++ b/spring-graalvm-native-docs/src/main/asciidoc/support.adoc
@@ -18,6 +18,7 @@ The following starters are supported, the group ID is `org.springframework.boot`
 * `spring-boot-starter-actuator`: WebMvc and WebFlux are supported, as well as metrics and tracing infrastructure. Beware that actuators significantly increase the footprint, this will be optimized in a future release.
 ** `--enable-https` flag is required for HTTPS support.
 * `spring-boot-starter-cache`
+* `spring-boot-starter-data-elasticsearch`
 * `spring-boot-starter-data-jdbc`
 ** `--enable-all-security-services` and `-H:+AddAllCharsets` may be required depending on your JDBC driver.
 * `spring-boot-starter-data-jpa`

--- a/spring-graalvm-native-samples/data-elasticsearch/pom.xml
+++ b/spring-graalvm-native-samples/data-elasticsearch/pom.xml
@@ -45,11 +45,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-elasticsearch</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/spring-graalvm-native-samples/data-elasticsearch/src/main/resources/application.properties
+++ b/spring-graalvm-native-samples/data-elasticsearch/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 #spring.elasticsearch.rest.uris=http://host.docker.internal:9200
 #spring.data.elasticsearch.client.reactive.endpoints=host.docker.internal
+#logging.level.root=DEBUG
+#logging.level.org.springframework.data.elasticsearch.client.WIRE=TRACE


### PR DESCRIPTION
Update hints for Elasticsearch now initializing Apache Lucene types at build time that prevented `org.elasticsearch.action.index.IndexRequest` from being created.
Allow `org.elasticsearch.Version` to reflectively read its own fields to avoid errors when accessing those via index on an otherwise empty list.
Also fix issues with netty types as part of the ES client.

Closes: #366