### PR TITLE
Pass args forward to Spring application.

### DIFF
--- a/spring-graalvm-native-samples/data-neo4j/src/main/java/com/example/data/neo4j/Neo4jApplication.java
+++ b/spring-graalvm-native-samples/data-neo4j/src/main/java/com/example/data/neo4j/Neo4jApplication.java
@@ -23,7 +23,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Neo4jApplication {
 
 	public static void main(String[] args) throws Exception {
-		SpringApplication.run(Neo4jApplication.class);
+		SpringApplication.run(Neo4jApplication.class, args);
 		Thread.currentThread().join(); // To be able to measure memory consumption
 	}
 }


### PR DESCRIPTION
This should fix the docker / CI build… 
I am unsure how that worked before, but in anyway, the environment is not forwarded. I guess other stores like Mongo are affected as well when they use an external docker or database instance. 

Paging @christophstrobl here as he notified me about the issue.

