### PR TITLE
Provide hsqldb database support (issue 303)

### DIFF
--- a/spring-graalvm-native-configuration/pom.xml
+++ b/spring-graalvm-native-configuration/pom.xml
@@ -114,6 +114,11 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.hsqldb</groupId>
+			<artifactId>hsqldb</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-function-web</artifactId>
 			<version>3.0.3.RELEASE</version>

--- a/spring-graalvm-native-configuration/src/main/java/org/hsqldb/HSQLDBHints.java
+++ b/spring-graalvm-native-configuration/src/main/java/org/hsqldb/HSQLDBHints.java
@@ -1,0 +1,21 @@
+package org.hsqldb;
+
+import org.hsqldb.jdbc.JDBCDriver;
+import org.hsqldb.lib.FileUtil;
+import org.springframework.nativex.extension.NativeImageConfiguration;
+import org.springframework.nativex.extension.NativeImageHint;
+import org.springframework.nativex.extension.ResourcesInfo;
+import org.springframework.nativex.extension.TypeInfo;
+import org.springframework.nativex.type.AccessBits;
+
+
+@NativeImageHint(trigger=JDBCDriver.class, typeInfos = {
+    @TypeInfo( types= {FileUtil.class},
+            typeNames= {"org.hsqldb.dbinfo.DatabaseInformationFull"}, access=AccessBits.LOAD_AND_CONSTRUCT)
+}, resourcesInfos = {
+    @ResourcesInfo(patterns = {"org/hsqldb/resources/information-schema.sql", "org/hsqldb/resources/lob-schema.sql", "org/hsqldb/resources/jdklogging-default.properties"}),
+    @ResourcesInfo(isBundle = true, patterns = "org.hsqldb.resources.sql-state-messages")
+})
+public class HSQLDBHints implements NativeImageConfiguration {
+
+}

--- a/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaHints.java
+++ b/spring-graalvm-native-configuration/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaHints.java
@@ -38,6 +38,7 @@ import org.hibernate.Session;
 import org.hibernate.annotations.Tuplizer;
 import org.hibernate.cache.spi.access.CollectionDataAccess;
 import org.hibernate.dialect.H2Dialect;
+import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform;
 import org.hibernate.event.spi.AutoFlushEventListener;
@@ -156,6 +157,7 @@ import org.springframework.stereotype.Repository;
 				BasicCollectionPersister.class,
 				H2Dialect.class,
 				MySQLDialect.class,
+				HSQLDialect.class,
 				SessionImpl.class,
 				EventType.class,
 				// Related to EventListenerRegistry...

--- a/spring-graalvm-native-configuration/src/main/resources/META-INF/services/org.springframework.nativex.extension.NativeImageConfiguration
+++ b/spring-graalvm-native-configuration/src/main/resources/META-INF/services/org.springframework.nativex.extension.NativeImageConfiguration
@@ -1,4 +1,5 @@
 org.h2.H2Hints
+org.hsqldb.HSQLDBHints
 com.mysql.cj.MySqlHints
 com.wavefront.spring.actuate.WavefrontEndpointHints
 com.wavefront.spring.actuate.WavefrontHints

--- a/spring-graalvm-native-samples/petclinic-jpa/pom.xml
+++ b/spring-graalvm-native-samples/petclinic-jpa/pom.xml
@@ -106,6 +106,11 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- caching -->
         <dependency>

--- a/spring-graalvm-native-samples/petclinic-jpa/readme.md
+++ b/spring-graalvm-native-samples/petclinic-jpa/readme.md
@@ -5,3 +5,8 @@ To build and run the native application packaged in a lightweight container with
 mvn spring-boot:build-image
 docker-compose up
 ```
+
+To test hsqldb database:
+
+ * update *pom.xml*, set scope of hsqldb dependency as runtime
+ * update *docker-compose.yml*, add the following environment variable to petclinic-jpa: *spring_profiles_active=hsqldb*

--- a/spring-graalvm-native-samples/petclinic-jpa/src/main/resources/application-hsqldb.properties
+++ b/spring-graalvm-native-samples/petclinic-jpa/src/main/resources/application-hsqldb.properties
@@ -1,0 +1,8 @@
+# database init, supports mysql too
+database=hsqldb
+spring.datasource.url=
+spring.datasource.schema=classpath*:db/${database}/schema.sql
+spring.datasource.data=classpath*:db/${database}/data.sql
+spring.datasource.initialization-mode=always
+#spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
+spring.jpa.database-platform=org.hibernate.dialect.HSQLDialect

--- a/spring-graalvm-native-samples/petclinic-jpa/src/main/resources/db/hsqldb/data.sql
+++ b/spring-graalvm-native-samples/petclinic-jpa/src/main/resources/db/hsqldb/data.sql
@@ -1,0 +1,55 @@
+INSERT INTO vets VALUES (1, 'James', 'Carter');
+INSERT INTO vets VALUES (2, 'Helen', 'Leary');
+INSERT INTO vets VALUES (3, 'Linda', 'Douglas');
+INSERT INTO vets VALUES (4, 'Rafael', 'Ortega');
+INSERT INTO vets VALUES (5, 'Henry', 'Stevens');
+INSERT INTO vets VALUES (6, 'Sharon', 'Jenkins');
+INSERT INTO vets VALUES (7, 'Edmund', 'Frankl');
+INSERT INTO vets VALUES (8, 'Benjamin', 'Top');
+
+INSERT INTO specialties VALUES (1, 'radiology');
+INSERT INTO specialties VALUES (2, 'surgery');
+INSERT INTO specialties VALUES (3, 'dentistry');
+
+INSERT INTO vet_specialties VALUES (2, 1);
+INSERT INTO vet_specialties VALUES (3, 2);
+INSERT INTO vet_specialties VALUES (3, 3);
+INSERT INTO vet_specialties VALUES (4, 2);
+INSERT INTO vet_specialties VALUES (5, 1);
+
+INSERT INTO types VALUES (1, 'cat');
+INSERT INTO types VALUES (2, 'dog');
+INSERT INTO types VALUES (3, 'lizard');
+INSERT INTO types VALUES (4, 'snake');
+INSERT INTO types VALUES (5, 'bird');
+INSERT INTO types VALUES (6, 'hamster');
+
+INSERT INTO owners VALUES (1, 'George', 'Franklin', '110 W. Liberty St.', 'Madison', '6085551023');
+INSERT INTO owners VALUES (2, 'Betty', 'Davis', '638 Cardinal Ave.', 'Sun Prairie', '6085551749');
+INSERT INTO owners VALUES (3, 'Eduardo', 'Rodriquez', '2693 Commerce St.', 'McFarland', '6085558763');
+INSERT INTO owners VALUES (4, 'Harold', 'Davis', '563 Friendly St.', 'Windsor', '6085553198');
+INSERT INTO owners VALUES (5, 'Peter', 'McTavish', '2387 S. Fair Way', 'Madison', '6085552765');
+INSERT INTO owners VALUES (6, 'Jean', 'Coleman', '105 N. Lake St.', 'Monona', '6085552654');
+INSERT INTO owners VALUES (7, 'Jeff', 'Black', '1450 Oak Blvd.', 'Monona', '6085555387');
+INSERT INTO owners VALUES (8, 'Maria', 'Escobito', '345 Maple St.', 'Madison', '6085557683');
+INSERT INTO owners VALUES (9, 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435');
+INSERT INTO owners VALUES (10, 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
+
+INSERT INTO pets VALUES (1, 'Leo', '2010-09-07', 1, 1);
+INSERT INTO pets VALUES (2, 'Basil', '2012-08-06', 6, 2);
+INSERT INTO pets VALUES (3, 'Rosy', '2011-04-17', 2, 3);
+INSERT INTO pets VALUES (4, 'Jewel', '2010-03-07', 2, 3);
+INSERT INTO pets VALUES (5, 'Iggy', '2010-11-30', 3, 4);
+INSERT INTO pets VALUES (6, 'George', '2010-01-20', 4, 5);
+INSERT INTO pets VALUES (7, 'Samantha', '2012-09-04', 1, 6);
+INSERT INTO pets VALUES (8, 'Max', '2012-09-04', 1, 6);
+INSERT INTO pets VALUES (9, 'Lucky', '2011-08-06', 5, 7);
+INSERT INTO pets VALUES (10, 'Mulligan', '2007-02-24', 2, 8);
+INSERT INTO pets VALUES (11, 'Freddy', '2010-03-09', 5, 9);
+INSERT INTO pets VALUES (12, 'Lucky', '2010-06-24', 2, 10);
+INSERT INTO pets VALUES (13, 'Sly', '2012-06-08', 1, 10);
+
+INSERT INTO visits VALUES (1, 7, '2013-01-01', 'rabies shot');
+INSERT INTO visits VALUES (2, 8, '2013-01-02', 'rabies shot');
+INSERT INTO visits VALUES (3, 8, '2013-01-03', 'neutered');
+INSERT INTO visits VALUES (4, 7, '2013-01-04', 'spayed');

--- a/spring-graalvm-native-samples/petclinic-jpa/src/main/resources/db/hsqldb/schema.sql
+++ b/spring-graalvm-native-samples/petclinic-jpa/src/main/resources/db/hsqldb/schema.sql
@@ -1,0 +1,64 @@
+DROP TABLE vet_specialties IF EXISTS;
+DROP TABLE vets IF EXISTS;
+DROP TABLE specialties IF EXISTS;
+DROP TABLE visits IF EXISTS;
+DROP TABLE pets IF EXISTS;
+DROP TABLE types IF EXISTS;
+DROP TABLE owners IF EXISTS;
+
+
+CREATE TABLE vets (
+  id         INTEGER IDENTITY PRIMARY KEY,
+  first_name VARCHAR(30),
+  last_name  VARCHAR(30)
+);
+CREATE INDEX vets_last_name ON vets (last_name);
+
+CREATE TABLE specialties (
+  id   INTEGER IDENTITY PRIMARY KEY,
+  name VARCHAR(80)
+);
+CREATE INDEX specialties_name ON specialties (name);
+
+CREATE TABLE vet_specialties (
+  vet_id       INTEGER NOT NULL,
+  specialty_id INTEGER NOT NULL
+);
+ALTER TABLE vet_specialties ADD CONSTRAINT fk_vet_specialties_vets FOREIGN KEY (vet_id) REFERENCES vets (id);
+ALTER TABLE vet_specialties ADD CONSTRAINT fk_vet_specialties_specialties FOREIGN KEY (specialty_id) REFERENCES specialties (id);
+
+CREATE TABLE types (
+  id   INTEGER IDENTITY PRIMARY KEY,
+  name VARCHAR(80)
+);
+CREATE INDEX types_name ON types (name);
+
+CREATE TABLE owners (
+  id         INTEGER IDENTITY PRIMARY KEY,
+  first_name VARCHAR(30),
+  last_name  VARCHAR_IGNORECASE(30),
+  address    VARCHAR(255),
+  city       VARCHAR(80),
+  telephone  VARCHAR(20)
+);
+CREATE INDEX owners_last_name ON owners (last_name);
+
+CREATE TABLE pets (
+  id         INTEGER IDENTITY PRIMARY KEY,
+  name       VARCHAR(30),
+  birth_date DATE,
+  type_id    INTEGER NOT NULL,
+  owner_id   INTEGER NOT NULL
+);
+ALTER TABLE pets ADD CONSTRAINT fk_pets_owners FOREIGN KEY (owner_id) REFERENCES owners (id);
+ALTER TABLE pets ADD CONSTRAINT fk_pets_types FOREIGN KEY (type_id) REFERENCES types (id);
+CREATE INDEX pets_name ON pets (name);
+
+CREATE TABLE visits (
+  id          INTEGER IDENTITY PRIMARY KEY,
+  pet_id      INTEGER NOT NULL,
+  visit_date  DATE,
+  description VARCHAR(255)
+);
+ALTER TABLE visits ADD CONSTRAINT fk_visits_pets FOREIGN KEY (pet_id) REFERENCES pets (id);
+CREATE INDEX visits_pet_id ON visits (pet_id);

--- a/spring-graalvm-native-substitutions/src/main/java/org/hsqldb/lib/Target_FrameworkLogger.java
+++ b/spring-graalvm-native-substitutions/src/main/java/org/hsqldb/lib/Target_FrameworkLogger.java
@@ -1,0 +1,13 @@
+package org.hsqldb.lib;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.springframework.nativex.substitutions.OnlyIfPresent;
+
+@TargetClass(className = "org.hsqldb.lib.FrameworkLogger", onlyWith = { OnlyIfPresent.class })
+public final class Target_FrameworkLogger {
+    @Substitute
+    public static boolean isDefaultJdkConfig() {
+        return true;
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/spring-projects-experimental/spring-graalvm-native/issues/303

Add a new hint _HSQLDBHints_ to import required class and resources.

Add a substitute to **hsqlb** class _FrameworkLogger_. This class attempts to retrieve log configuration at runtime but cannot find them since the property _java.home_ is not set (see https://sourceforge.net/p/hsqldb/src/org/
hsqldb/lib/FrameworkLogger.java#l364).
To workaround this issue the method _isDefaultJdkConfig_ is overriden.