### PR TITLE
GH-407 - Fix missing proxy configuration for Spring Data repositories annotated with Component.

### DIFF
--- a/spring-graalvm-native-configuration/src/main/java/org/springframework/data/SpringDataComponentProcessor.java
+++ b/spring-graalvm-native-configuration/src/main/java/org/springframework/data/SpringDataComponentProcessor.java
@@ -203,6 +203,17 @@ public class SpringDataComponentProcessor implements ComponentProcessor {
 			// transactional
 			imageContext.addProxy(repositoryType.getDottedName(), repositoryName, "org.springframework.transaction.interceptor.TransactionalProxy",
 					"org.springframework.aop.framework.Advised", "org.springframework.core.DecoratingProxy");
+
+			/*
+			 * Generated proxies extend Proxy and Proxy implements Serializable. So the call:
+			 * 	    protected void evaluateProxyInterfaces(Class<?> beanClass, ProxyFactory proxyFactory) {
+			 * 		    Class<?>[] targetInterfaces = ClassUtils.getAllInterfacesForClass(beanClass, getProxyClassLoader());
+			 * is going to find targetInterfaces contains Serializable when called on the beanClass.
+			 */
+			if (repositoryType.isAtComponent()) {
+				imageContext.addProxy(repositoryType.getDottedName(), repositoryName, "org.springframework.transaction.interceptor.TransactionalProxy",
+						"org.springframework.aop.framework.Advised", "org.springframework.core.DecoratingProxy", "java.io.Serializable");
+			}
 		}
 
 		// reactive repo


### PR DESCRIPTION
We require the additional proxy configuration (including `java.io.Serializable`) if the target repository is annotated with eg. `org.springframework.stereotype.Repository` because generated proxies extend `Proxy` and `Proxy` implements `Serializable`.

Closes: #407 