### PR TITLE
Removing extra spring-context-indexer

### DIFF
--- a/spring-graalvm-native-samples/hibernate/pom.xml
+++ b/spring-graalvm-native-samples/hibernate/pom.xml
@@ -30,10 +30,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
-			<artifactId>spring-context-indexer</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
 			<artifactId>spring-orm</artifactId>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
spring-context-indexer is duplicated between line 30 and 80